### PR TITLE
Added check for if the configured backup is an NFS mount

### DIFF
--- a/ssp_modular/lib/Warn/OS.pm
+++ b/ssp_modular/lib/Warn/OS.pm
@@ -485,4 +485,15 @@ sub check_bash_history_for_certain_commands {
     }
 }
 
+sub check_for_direct_nfs_backup {
+    my $backupdir  = `grep \"BACKUPDIR:\" /var/cpanel/backups/config | awk '{print \$2}'`;
+    chomp($backupdir);
+    my $check = "mount | grep '$backupdir type nfs' | wc -l";
+    $check = `$check`;
+    if ($check > 0) {
+        print_warn("Backup:");
+        print_warning("Backup directory ($backupdir) is an NFS mount");
+    }
+}
+    
 1;

--- a/ssp_modular/scripts/main.pl
+++ b/ssp_modular/scripts/main.pl
@@ -201,6 +201,7 @@ Warn::Yum::check_for_wget_exclude();
 Warn::Yum::check_for_odd_yumconf();
 Warn::ImageMagick::check_for_multiple_imagemagick_installs();
 Warn::RPM::check_for_rpm_overrides();
+Warn::OS::check_for_direct_nfs_backup();
 
 ## [3RDP]
 ThirdParty::ASSP::assp();


### PR DESCRIPTION
Added a check for if the configured backup directory is an NFS mount.

This doesn't always create problems,  but it can,  is out of scope and the analyst should be made aware of the condition.
