### PR TITLE
This commit fixes an issue where an undefined variable can get all the w...

### DIFF
--- a/ssp
+++ b/ssp
@@ -1353,7 +1353,7 @@ sub print_php_configuration {
         if (/^php5:[ \t]+['"]?([^'"]+)/) {
             $php5handler = $1;
         }
-        if (/^suexec:[ \t]+['"]?([^'"]+)/) {
+        if (/^suexec:[ \t]+['"]?([0-9]?)['"]?/) {
             $suexec = $1;
         }
     }
@@ -4375,7 +4375,7 @@ sub check_for_rpm_dist_ver_unknown {
 }
 
 sub check_for_homeloader_php_extension {
-    return if ( $php5handler ne 'dso' );
+    return if ( defined $php5handler && $php5handler ne 'dso' );
 
     if ( grep { m# \A ([\s\t]+)? extension ([\s\t]+)? = ([\s\t]+)? ["']? homeloader\.so ['"]? #xms } @phpini ) {
         print_warn('/usr/local/lib/php.ini: ');
@@ -4785,7 +4785,7 @@ sub check_for_nocloudlinux_touchfile {
 }
 
 sub check_for_phphandler_and_opcode_caching_incompatibility {
-    return if ( $php5handler ne 'suphp' );
+    return if ( defined $php5handler && $php5handler ne 'suphp' );
 
     my $message;
 


### PR DESCRIPTION
...ay to printing out an error in the terminal, as well as a minor regex change for suexec checking

The error for php5handler was this:

```
[WARN] * /root/.bash_history commands found: [chmod]
Use of uninitialized value $php5handler in string ne at - line 4378.
[WARN] * Disabled services: [httpd]
Use of uninitialized value $php5handler in string ne at - line 4788.
[WARN] * Backups: /var/cpanel/backuprunning exists, but pid 27892 not found in process list
RPM check (running "rpm -qa ..."). This will timeout after 15 seconds.
```

The suexec regex would not capture anything if the line in `/usr/local/apache/conf/php.conf.yaml` was something like this:
    suexec: ''
