### PR TITLE
Check for w-x backup directories

### DIFF
--- a/ssp
+++ b/ssp
@@ -72,6 +72,8 @@ our @RPM_LIST;                  # rpm -qa
 our %CPCONF;                    # cpanel.config
 our %PUREFTPDCONF;              # /etc/pure-ftpd.conf
 our %PROFTPDCONF;               # /etc/proftpd.conf
+our $OLD_BACKUP_CONF;           # /etc/cpbackup.conf
+our $NEW_BACKUP_CONF;           # /var/cpanel/backups/config
 our @APACHE_VERSION_OUTPUT;     # httpd -v
 our @APACHE_MODULES_OUTPUT;     # httpd -M
 our $APACHE_VERSION;            # Version string
@@ -114,21 +116,22 @@ sub init {
     $LIBKEYUTILS_FILES_REF    = build_libkeyutils_file_list();
     $HOSTNAME                 = hostname();
     $OS                       = get_os();
+    $TIERS                    = get_tiers_file();
+    @LOCAL_IPADDRS_LIST       = get_local_ipaddrs();
+    @PROCESS_LIST             = get_process_list();
+    $PROCESS_REF              = get_process_pid_hash();
+    $PORT_REF                 = get_lsof_port_hash();
+    $IPCS_REF                 = get_ipcs_hash();
+    $HOSTINFO                 = get_hostinfo();
+    $CPUINFO                  = get_cpuinfo();
+    $SYSCTL                   = get_sysctl();
+    $MYSQL_CONF               = get_mysql_conf();
+    $MYSQL_DATADIR            = get_mysql_datadir();             # needs $MYSQL_CONF
+    $MYSQL_ERROR_LOG          = get_mysql_error_log();           # needs $MYSQL_CONF
+    $EA4_PHP_FPM              = get_ea4_php_fpm_status();
+    $APACHE_PER_USER          = "none";
     ( $OS_RELEASE, $OS_ISES ) = get_release_version();
-    $TIERS              = get_tiers_file();
-    @LOCAL_IPADDRS_LIST = get_local_ipaddrs();
-    @PROCESS_LIST       = get_process_list();
-    $PROCESS_REF        = get_process_pid_hash();
-    $PORT_REF           = get_lsof_port_hash();
-    $IPCS_REF           = get_ipcs_hash();
-    $HOSTINFO           = get_hostinfo();
-    $CPUINFO            = get_cpuinfo();
-    $SYSCTL             = get_sysctl();
-    $MYSQL_CONF         = get_mysql_conf();
-    $MYSQL_DATADIR      = get_mysql_datadir();        # needs $MYSQL_CONF
-    $MYSQL_ERROR_LOG    = get_mysql_error_log();      # needs $MYSQL_CONF
-    $EA4_PHP_FPM        = get_ea4_php_fpm_status();
-    $APACHE_PER_USER    = "none";
+    ( $OLD_BACKUP_CONF, $NEW_BACKUP_CONF ) = get_backup_config();
     ( $LSWS_FULL_VERSION, $LSWS_NUMERIC_VERSION ) = get_lsws_version();
 
     if ($HTTPD_PATH) {
@@ -2126,6 +2129,27 @@ sub print_mysql_version {
     }
 }
 
+sub get_backup_config {
+    my $new_backup_dir    = '/var/cpanel/backups/';
+    my $new_backup_config = $new_backup_dir . 'config';
+    my $old_backup_config = '/etc/cpbackup.conf';
+    my ( $new, $old );
+
+    if ( -f $new_backup_config && open( my $backupconf_fh, '<', $new_backup_config ) ) {
+        local $/ = undef;
+        $new = { map { ( split( /:\s/, $_, 2 ) )[ 0, 1 ] } split( /\n/, readline($backupconf_fh) ) };
+        close $backupconf_fh;
+    }
+
+    if ( -f $old_backup_config && open( my $backupconf_fh, '<', $old_backup_config ) ) {
+        local $/ = undef;
+        $old = { map { ( split( /\s/, $_, 2 ) )[ 0, 1 ] } split( /\n/, readline($backupconf_fh) ) };
+        close $backupconf_fh;
+    }
+
+    return ( $old, $new );
+}
+
 sub print_backups_info {
     my %new      = ();
     my %new_dest = ();
@@ -2137,19 +2161,9 @@ sub print_backups_info {
     my $new_backup_config = $new_backup_dir . 'config';
     my $old_backup_config = '/etc/cpbackup.conf';
 
-    if ( -f $new_backup_config && open( my $backupconf_fh, '<', $new_backup_config ) ) {
-        local $/ = undef;
-        %new = map { ( split( /:\s/, $_, 2 ) )[ 0, 1 ] } split( /\n/, readline($backupconf_fh) );
-        close $backupconf_fh;
-    }
+    my ( $new, $old ) = get_backup_config();
 
-    if ( -f $old_backup_config && open( my $backupconf_fh, '<', $old_backup_config ) ) {
-        local $/ = undef;
-        %old = map { ( split( /\s/, $_, 2 ) )[ 0, 1 ] } split( /\n/, readline($backupconf_fh) );
-        close $backupconf_fh;
-    }
-
-    if ( defined( $new{'BACKUPENABLE'} ) && $new{'BACKUPENABLE'} =~ /yes/ ) {
+    if ( defined( $NEW_BACKUP_CONF->{'BACKUPENABLE'} ) && $NEW_BACKUP_CONF->{'BACKUPENABLE'} =~ /yes/ ) {
         my @dir_contents = ();
         if ( opendir( my $dir_fh, $new_backup_dir ) ) {
             @dir_contents = readdir $dir_fh;
@@ -2167,7 +2181,7 @@ sub print_backups_info {
         }
     }
 
-    if ( ( defined( $old{'BACKUPENABLE'} ) and $old{'BACKUPENABLE'} eq 'yes' ) or ( defined( $new{'BACKUPENABLE'} ) and $new{'BACKUPENABLE'} =~ /yes/ ) ) {
+    if ( ( defined( $OLD_BACKUP_CONF->{'BACKUPENABLE'} ) and $OLD_BACKUP_CONF->{'BACKUPENABLE'} eq 'yes' ) or ( defined( $NEW_BACKUP_CONF->{'BACKUPENABLE'} ) and $NEW_BACKUP_CONF->{'BACKUPENABLE'} =~ /yes/ ) ) {
         if ( open my $file_fh, '<', '/var/spool/cron/root' ) {
             while (<$file_fh>) {
                 if (m{ \A [^#] .+ /usr/local/cpanel/scripts/cpbackup }xms) {
@@ -2181,23 +2195,23 @@ sub print_backups_info {
         }
     }
 
-    if ( defined( $new{'BACKUPENABLE'} ) ) {
-        if ( $new{'BACKUPENABLE'} =~ /yes/ ) {
+    if ( defined( $NEW_BACKUP_CONF->{'BACKUPENABLE'} ) ) {
+        if ( $NEW_BACKUP_CONF->{'BACKUPENABLE'} =~ /yes/ ) {
             $new_backups_status = 'Enabled';
-            if ( defined( $new{'BACKUPACCTS'} ) && $new{'BACKUPACCTS'} =~ /yes/ ) {
+            if ( defined( $NEW_BACKUP_CONF->{'BACKUPACCTS'} ) && $NEW_BACKUP_CONF->{'BACKUPACCTS'} =~ /yes/ ) {
                 $new_backups_status .= '/WithAccounts';
             }
-            elsif ( defined( $new{'BACKUPACCTS'} ) && $new{'BACKUPACCTS'} =~ /no/ ) {
+            elsif ( defined( $NEW_BACKUP_CONF->{'BACKUPACCTS'} ) && $NEW_BACKUP_CONF->{'BACKUPACCTS'} =~ /no/ ) {
                 $new_backups_status .= '/NoAccounts';
             }
 
-            if ( defined( $new{'BACKUPTYPE'} ) && $new{'BACKUPTYPE'} =~ /uncompressed/ ) {
+            if ( defined( $NEW_BACKUP_CONF->{'BACKUPTYPE'} ) && $NEW_BACKUP_CONF->{'BACKUPTYPE'} =~ /uncompressed/ ) {
                 $new_backups_status .= '/Uncompressed';
             }
-            elsif ( defined( $new{'BACKUPTYPE'} ) && $new{'BACKUPTYPE'} =~ /compressed/ ) {
+            elsif ( defined( $NEW_BACKUP_CONF->{'BACKUPTYPE'} ) && $NEW_BACKUP_CONF->{'BACKUPTYPE'} =~ /compressed/ ) {
                 $new_backups_status .= '/Compressed';
             }
-            elsif ( defined( $new{'BACKUPTYPE'} ) && $new{'BACKUPTYPE'} =~ /incremental/ ) {
+            elsif ( defined( $NEW_BACKUP_CONF->{'BACKUPTYPE'} ) && $NEW_BACKUP_CONF->{'BACKUPTYPE'} =~ /incremental/ ) {
                 $new_backups_status .= '/Incremental';
             }
             else {
@@ -2209,31 +2223,31 @@ sub print_backups_info {
                 $warning = 1;
             }
         }
-        elsif ( $new{'BACKUPENABLE'} =~ /no/ ) {
+        elsif ( $NEW_BACKUP_CONF->{'BACKUPENABLE'} =~ /no/ ) {
             $new_backups_status = 'Disabled';
         }
     }
 
-    if ( defined( $old{'BACKUPENABLE'} ) ) {
-        if ( $old{'BACKUPENABLE'} eq 'restoreonly' ) {
+    if ( defined( $OLD_BACKUP_CONF->{'BACKUPENABLE'} ) ) {
+        if ( $OLD_BACKUP_CONF->{'BACKUPENABLE'} eq 'restoreonly' ) {
             $old_backups_status = 'RestoreOnly';
         }
-        elsif ( $old{'BACKUPENABLE'} eq 'yes' ) {
+        elsif ( $OLD_BACKUP_CONF->{'BACKUPENABLE'} eq 'yes' ) {
             $old_backups_status = 'Enabled';
-            if ( defined( $old{'BACKUPACCTS'} ) && $old{'BACKUPACCTS'} eq 'yes' ) {
+            if ( defined( $old->{'BACKUPACCTS'} ) && $old->{'BACKUPACCTS'} eq 'yes' ) {
                 $old_backups_status .= '/WithAccounts';
             }
-            elsif ( defined( $old{'BACKUPACCTS'} ) && $old{'BACKUPACCTS'} eq 'no' ) {
+            elsif ( defined( $OLD_BACKUP_CONF->{'BACKUPACCTS'} ) && $OLD_BACKUP_CONF->{'BACKUPACCTS'} eq 'no' ) {
                 $old_backups_status .= '/NoAccounts';
             }
 
-            if ( defined( $old{'BACKUPINC'} ) && $old{'BACKUPINC'} eq 'yes' ) {
+            if ( defined( $OLD_BACKUP_CONF->{'BACKUPINC'} ) && $OLD_BACKUP_CONF->{'BACKUPINC'} eq 'yes' ) {
                 $old_backups_status .= '/Incremental';
             }
-            elsif ( defined( $old{'COMPRESSACCTS'} ) && $old{'COMPRESSACCTS'} eq 'yes' ) {
+            elsif ( defined( $OLD_BACKUP_CONF->{'COMPRESSACCTS'} ) && $OLD_BACKUP_CONF->{'COMPRESSACCTS'} eq 'yes' ) {
                 $old_backups_status .= '/Compressed';
             }
-            elsif ( defined( $old{'COMPRESSACCTS'} ) && $old{'COMPRESSACCTS'} eq 'no' ) {
+            elsif ( defined( $OLD_BACKUP_CONF->{'COMPRESSACCTS'} ) && $OLD_BACKUP_CONF->{'COMPRESSACCTS'} eq 'no' ) {
                 $old_backups_status .= '/Uncompressed';
             }
             else {
@@ -2245,13 +2259,13 @@ sub print_backups_info {
                 $warning = 1;
             }
         }
-        elsif ( $old{'BACKUPENABLE'} eq 'no' ) {
+        elsif ( $OLD_BACKUP_CONF->{'BACKUPENABLE'} eq 'no' ) {
             $old_backups_status = 'Disabled';
         }
     }
 
     if ( keys(%new_dest) ) {
-        if ( defined( $new{'KEEPLOCAL'} ) && $new{'KEEPLOCAL'} =~ /1/ ) {
+        if ( defined( $NEW_BACKUP_CONF->{'KEEPLOCAL'} ) && $NEW_BACKUP_CONF->{'KEEPLOCAL'} =~ /1/ ) {
             $new_backups_status .= '/RetainLocal';
         }
         else {
@@ -3099,6 +3113,16 @@ sub check_for_non_default_permissions {
         else {
             $check{'/usr/bin/python'} = { mode => ['0755'], perms_help => 'If the Python binary is not executable by non-root users it can break CloudLinux functions in cPanel UI' };
         }
+    }
+
+    my @backup_path_parts = split( '/', $NEW_BACKUP_CONF->{BACKUPDIR} );
+
+    # the first element will be an empty string. We don't want to check the permissions of /.
+    shift @backup_path_parts;
+    my $backup_path_parent = '/';
+    foreach my $part (@backup_path_parts) {
+        $backup_path_parent .= "$part/";
+        $check{$backup_path_parent} = { mode => ['0711'], perms_help => "backups subtly wrong unless the backup directory and all its parents have w+x. See CPANEL-4336." };
     }
 
     for my $path ( sort keys %check ) {


### PR DESCRIPTION
Case TECH-57: In CPANEL-4336, we determined that non-world-execute
directories in the path to the backup destination will cause .htaccess
files not to be modified correctly under some circumstances. Check
permissions and warn if any backup parent directories lack world-execute
permission.