### PR TITLE
Fix uninit warning on EA4-only systems

### DIFF
--- a/ssp
+++ b/ssp
@@ -6957,7 +6957,7 @@ sub check_for_cl_unsupported_memory_limits {
         print_warn('LiteSpeed: ');
         print_warning('in use on CL5 or earlier. CloudLinux memory limits not imposed on Apache processes.');
     }
-    if ( $EA3_PHP5HANDLER eq "dso" && version_compare( $OS_RELEASE, qw( < 6 ) ) ) {
+    if ( defined $EA3_PHP5HANDLER && $EA3_PHP5HANDLER eq "dso" && version_compare( $OS_RELEASE, qw( < 6 ) ) ) {
         print_warn('PHP DSO: ');
         print_warning('in use on CL 5 or earlier. CloudLinux memory limits not imposed on Apache processes.');
     }


### PR DESCRIPTION
Case TECH-69: On systems where EasyApache 3 never ran, some EA3-specific
variables will not be defined. In that case, skip checking the EA3 PHP
handler.